### PR TITLE
FormatsContainer: the difference between $list and addDefaults

### DIFF
--- a/src/Schema/TypeFormats/FormatsContainer.php
+++ b/src/Schema/TypeFormats/FormatsContainer.php
@@ -51,8 +51,8 @@ class FormatsContainer
         self::registerFormat('string', 'ipv6', StringIP6::class);
 
         // number
-        self::registerFormat('string', 'float', NumberFloat::class);
-        self::registerFormat('string', 'double', NumberDouble::class);
+        self::registerFormat('number', 'float', NumberFloat::class);
+        self::registerFormat('number', 'double', NumberDouble::class);
     }
 
     /**


### PR DESCRIPTION
I'm not clear on the difference between 
```php
    private static $list = [
        'string' => [
            …
        ],
        'number' => [
            'float'  => NumberFloat::class,
            'double' => NumberDouble::class,
        ],
    ];
```
and
```php
    public static function addDefaults() : void
    {
        // string
        …

        // number
        self::registerFormat('string', 'float', NumberFloat::class);
        self::registerFormat('string', 'double', NumberDouble::class);
    }
```

I would expect the same result:
```php 
$initValues = FormatsContainer::$list;

FormatsContainer::flush();
FormatsContainer::addDefaults();

($initValues === FormatsContainer::$list) === true;
```